### PR TITLE
Add missing /refresh options into documentation

### DIFF
--- a/help/help.html
+++ b/help/help.html
@@ -361,14 +361,16 @@
         <li><code>/showFallbackFontDir</code> / <code>/openFallbackFontDir</code> - Show/open the directory where Java looks for <a href="help-troubleshooting.html#font">fallback fonts</a></li>
         <li><code>/showTempDir</code> / <code>/openTempDir</code> - Show/open the system's temp directory</li>
         <li><code>/exportText [-sna] &lt;fileName&gt; &lt;text&gt;</code> - Write the text to a file in the "exported" directory in the settings directory (UTF-8), <code>-s</code> for no info message when writing successfully, <code>-n</code> for replacing "\n" in the text with a newline, <code>-a</code> for appending to the file (Example: <code>/exportText -n abc.txt one\ntwo</code> - Writes "one" and "two" as separate lines)</li>
-        <li><code>/refresh &lt;emoticons/badges/ffz/ffzglobal/bttvemotes&gt;</code>
+        <li><code>/refresh &lt;emoticons/badges/bits/ffz/ffzglobal/bttvemotes/7tv&gt;</code>
             - Refresh the given data from it's respective API:
             <ul>
                 <li><code>emoticons</code>: Twitch Emotes</li>
                 <li><code>badges</code>: Twitch Badges (current channel)</li>
+                <li><code>bits</code>: Twitch Bits (current channel)</li>
                 <li><code>ffz</code>: FFZ Emotes (current channel)</li>
                 <li><code>ffzglobal</code>: Global FFZ Emotes</li>
                 <li><code>bttvemotes</code>: BTTV Emotes (global and current channel)</li>
+                <li><code>7tv</code>: 7TV Emotes (global and current channel)</li>
             </ul>
             <em>This downloads the lists from the Internet, which may be useful
                 if new emotes have been added (it's basicially like pressing


### PR DESCRIPTION
This merge request adds the missing options available to /refresh to the documentation so users don't have to browse through the source code to find them ;)